### PR TITLE
crypto_sign_ed25519_pk_to_curve25519 and crypto_sign_ed25519_sk_to_curve25519 fixed 

### DIFF
--- a/cpp/react-native-libsodium.cpp
+++ b/cpp/react-native-libsodium.cpp
@@ -696,7 +696,7 @@ namespace ReactNativeLibsodium
 
         auto jsi_crypto_sign_ed25519_pk_to_curve25519 = jsi::Function::createFromHostFunction(
             jsiRuntime,
-            jsi::PropNameID::forUtf8(jsiRuntime, "crypto_sign_ed25519_pk_to_curve25519"),
+            jsi::PropNameID::forUtf8(jsiRuntime, "jsi_crypto_sign_ed25519_pk_to_curve25519"),
             1,
             [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *arguments, size_t count) -> jsi::Value
             {
@@ -721,7 +721,7 @@ namespace ReactNativeLibsodium
 
         auto jsi_crypto_sign_ed25519_sk_to_curve25519 = jsi::Function::createFromHostFunction(
             jsiRuntime,
-            jsi::PropNameID::forUtf8(jsiRuntime, "crypto_sign_ed25519_sk_to_curve25519"),
+            jsi::PropNameID::forUtf8(jsiRuntime, "jsi_crypto_sign_ed25519_sk_to_curve25519"),
             1,
             [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *arguments, size_t count) -> jsi::Value
             {
@@ -743,7 +743,7 @@ namespace ReactNativeLibsodium
             });
 
         jsiRuntime.global().setProperty(jsiRuntime, "jsi_crypto_sign_ed25519_sk_to_curve25519", std::move(jsi_crypto_sign_ed25519_sk_to_curve25519));
-      
+
         auto jsi_crypto_secretbox_easy = jsi::Function::createFromHostFunction(
             jsiRuntime,
             jsi::PropNameID::forUtf8(jsiRuntime, "jsi_crypto_secretbox_easy"),

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,11 @@ import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import sodium, { loadSumoVersion, ready } from 'react-native-libsodium';
 import { TestResults } from './components/TestResults';
 import { VisualImageTest } from './components/VisualImageTest';
+import {
+  crypto_sign_seed_keypair,
+  crypto_sign_ed25519_sk_to_curve25519,
+  crypto_sign_ed25519_pk_to_curve25519,
+} from '../../src/lib.native';
 
 loadSumoVersion();
 
@@ -10,6 +15,7 @@ function LibsodiumTests() {
   if (sodium.crypto_secretbox_KEYBYTES !== 32) {
     throw new Error('export default not working');
   }
+  verify_soidum();
 
   return (
     <SafeAreaView style={styles.safeAreaContainer}>
@@ -21,6 +27,45 @@ function LibsodiumTests() {
       </ScrollView>
     </SafeAreaView>
   );
+}
+
+async function generateAsymmetricKey(iv = generateEntropy(32)) {
+  console.log(
+    'sodium crypto_sign_ed25519_pk_to_curve25519:',
+    crypto_sign_ed25519_pk_to_curve25519
+  );
+  console.log('sodium crypto_sign_seed_keypair:', crypto_sign_seed_keypair);
+
+  const ed25519KeyPair = crypto_sign_seed_keypair(iv);
+  console.log('PubKey: ', ed25519KeyPair.publicKey);
+  console.log('privateKey: ', ed25519KeyPair.privateKey);
+  console.log('Keypair: ', ed25519KeyPair);
+  // debugger;
+  const uint8_pubKey = new Uint8Array(ed25519KeyPair.publicKey);
+  console.log('uint8_pubKey', uint8_pubKey);
+  const uint8_privKey = new Uint8Array(ed25519KeyPair.privateKey);
+  console.log('uint8_privKey', uint8_privKey);
+  const uint8_encPK = crypto_sign_ed25519_pk_to_curve25519(uint8_pubKey);
+  const uint8_encSK = crypto_sign_ed25519_sk_to_curve25519(uint8_privKey);
+  console.log('uint8_encPK=', uint8_encPK);
+  console.log('uint8_encSK=', uint8_encSK);
+  // console.log("crypto_sign_ed25519_pk_to_curve25519", crypto_sign_ed25519_pk_to_curve25519(new Un));
+
+  return Promise.resolve({
+    iv,
+    publicKey: ed25519KeyPair.publicKey,
+    privateKey: ed25519KeyPair.privateKey,
+    encPK: crypto_sign_ed25519_pk_to_curve25519(ed25519KeyPair.publicKey),
+    encSK: crypto_sign_ed25519_sk_to_curve25519(ed25519KeyPair.privateKey),
+  });
+}
+function generateEntropy(numBytes = 16) {
+  return sodium.randombytes_buf(numBytes);
+}
+
+async function verify_soidum() {
+  const keyPairInfo = generateAsymmetricKey();
+  return keyPairInfo;
 }
 
 export default function App() {

--- a/src/lib.native.ts
+++ b/src/lib.native.ts
@@ -96,8 +96,12 @@ declare global {
     message: string | ArrayBuffer,
     publicKey: ArrayBuffer
   ): boolean;
-  function jsi_crypto_sign_ed25519_pk_to_curve25519(pk: ArrayBuffer): ArrayBuffer;
-  function jsi_crypto_sign_ed25519_sk_to_curve25519(sk: ArrayBuffer): ArrayBuffer;
+  function jsi_crypto_sign_ed25519_pk_to_curve25519(
+    pk: ArrayBuffer
+  ): ArrayBuffer;
+  function jsi_crypto_sign_ed25519_sk_to_curve25519(
+    sk: ArrayBuffer
+  ): ArrayBuffer;
   function jsi_crypto_secretbox_easy(
     message: string | ArrayBuffer,
     nonce: ArrayBuffer,
@@ -160,7 +164,7 @@ declare global {
     public_nonce: ArrayBuffer,
     key: ArrayBuffer
   ): ArrayBuffer;
-  function jsi_crypto_aead_xchacha20poly1305_ietf_decrypt(
+  function jsi_crypto_aead_xchacha20poly1305_ietf_decrypt( // This is duplicated
     ciphertext: string | ArrayBuffer,
     additionalData: string,
     public_nonce: ArrayBuffer,
@@ -420,13 +424,13 @@ export function crypto_sign_verify_detached(
 
 export function crypto_sign_ed25519_pk_to_curve25519(
   pk: Uint8Array
-): unknown {
+): ArrayBuffer {
   return global.jsi_crypto_sign_ed25519_pk_to_curve25519(pk.buffer);
 }
 
 export function crypto_sign_ed25519_sk_to_curve25519(
   sk: Uint8Array
-): unknown {
+): ArrayBuffer {
   return global.jsi_crypto_sign_ed25519_sk_to_curve25519(sk.buffer);
 }
 

--- a/src/lib.native.ts
+++ b/src/lib.native.ts
@@ -423,15 +423,19 @@ export function crypto_sign_verify_detached(
 }
 
 export function crypto_sign_ed25519_pk_to_curve25519(
-  pk: Uint8Array
-): ArrayBuffer {
-  return global.jsi_crypto_sign_ed25519_pk_to_curve25519(pk.buffer);
+  pk: Uint8Array,
+  outputFormat?: Uint8ArrayOutputFormat | null
+): string | Uint8Array {
+  const result = global.jsi_crypto_sign_ed25519_pk_to_curve25519(pk.buffer);
+  return convertToOutputFormat(result, outputFormat);
 }
 
 export function crypto_sign_ed25519_sk_to_curve25519(
-  sk: Uint8Array
-): ArrayBuffer {
-  return global.jsi_crypto_sign_ed25519_sk_to_curve25519(sk.buffer);
+  sk: Uint8Array,
+  outputFormat?: Uint8ArrayOutputFormat | null
+): string | Uint8Array {
+  const result = global.jsi_crypto_sign_ed25519_sk_to_curve25519(sk.buffer);
+  return convertToOutputFormat(result, outputFormat);
 }
 
 export function crypto_secretbox_easy(


### PR DESCRIPTION
The lab.native update was the main point.
Merging to put it to use with RN expo-demo.

**Todo before PR**
- Move App.tsk demonstration code into test cases
- Verify implementation with New Arch, expo and bare RN. 